### PR TITLE
lint-n-opti' 🧽  🧽  🧽

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM python:3-alpine
+FROM python:3.8-alpine3.10
 COPY . /app
 WORKDIR /app
-RUN apk add gcc musl-dev && pip install -r requirements.txt
-CMD python Bot.py
+
+RUN apk --update add --virtual build-dependencies gcc=8.3.0-r0 musl-dev=1.1.22-r3 --no-cache \
+  && pip install -r requirements.txt \
+  && apk del build-dependencies
+
+CMD ["python", "Bot.py"]


### PR DESCRIPTION
Resolves #9 

- 🧽 pin 🧽 all 🧽 the 🧽 things
- 🧽 use 🧽 `apk` 🧽 namespaces 🧽 to 🧽 install 🧽, 🧽 then 🧽 nuke 🧽, 🧽 some 🧽 _files_ 🧽