### PR TITLE
fix: update message time remaining

### DIFF
--- a/plugins/TodayAtMun/DiaryUtil.py
+++ b/plugins/TodayAtMun/DiaryUtil.py
@@ -17,9 +17,7 @@ class DiaryUtil:
         return datetime.strptime(str_date, "%B %d, %Y, %A")
 
     @staticmethod
-    def time_delta_event(
-        event_date: datetime, curr_date: datetime = datetime.now()
-    ) -> int:
+    def time_delta_event(event_date: datetime, curr_date: datetime) -> int:
         """Provides time delta of days remaining for a given date to current date."""
         return (
             DiaryUtil.truncate_date_time(event_date)
@@ -33,10 +31,12 @@ class DiaryUtil:
     @staticmethod
     def time_to_dt_delta(date: str) -> int:
         convert_date = DiaryUtil.str_to_datetime(date)
-        return DiaryUtil.time_delta_event(convert_date)
+        return DiaryUtil.time_delta_event(convert_date, datetime.now())
 
-    def time_delta_emojify(self) -> str:
-        remaining_time = DiaryUtil.time_delta_event(DiaryUtil.str_to_datetime(self.key))
+    def time_delta_emojify(self, next_event_date: str) -> str:
+        remaining_time = DiaryUtil.time_delta_event(
+            DiaryUtil.str_to_datetime(next_event_date), datetime.now()
+        )
         if remaining_time > 1:
             return f"⏳ {remaining_time} day(s)"
         elif 0 < remaining_time <= 1:
@@ -63,7 +63,7 @@ class DiaryUtil:
 
     def go_to_event(self) -> None:
         """Look up key in dict and set it to variable."""
-        self.this_date = self.diary[self.key]
+        self.event_desc = self.diary[self.key]
 
     def find_event(self, date: datetime) -> str:
         """Searches for date/event pair in MUN calendar."""

--- a/plugins/TodayAtMun/Tests/test.py
+++ b/plugins/TodayAtMun/Tests/test.py
@@ -3,11 +3,11 @@ import unittest
 from unittest.case import TestCase
 import pytest
 
-
 sys.path.append("../../../")
 from datetime import date, datetime, timedelta
 from plugins.TodayAtMun.DiaryUtil import DiaryUtil
 from plugins.TodayAtMun.__init__ import TodayAtMun
+
 
 class TestDateMethods(unittest.TestCase):
     """Testing TodayAtMun Plugin"""
@@ -98,11 +98,12 @@ def test_package_of_events():
         "December 10, 2010, Friday": "December is on the go",
         "December 30, 2010, Thursday": "NYE EVE",
         "December 31, 2010, Friday": "Friday NYE",
-        }
+    }
     date = datetime(2010, 10, 22)
     diary = DiaryUtil(diary_data)
     TestCase().assertDictEqual(diary.package_of_events(date, 4), test1_diary_expected)
     TestCase().assertDictEqual(diary.package_of_events(date, 5), test2_diary_expected)
+
 
 def test_find_event(parsed_diary):
 
@@ -119,3 +120,37 @@ def test_find_event(parsed_diary):
     diary_util = DiaryUtil(diary_data)
     assert diary_data[diary_util.find_event(date)] == "40 days away"
 
+
+def test_daily_time_delta():
+    time = datetime(2021, 10, 22)
+    diary = {
+        (time + timedelta(days=10)).strftime("%B %-d, %Y, %A"): "First event",
+        (time + timedelta(days=20)).strftime("%B %-d, %Y, %A"): "Second event",
+        (time + timedelta(days=30)).strftime("%B %-d, %Y, %A"): "Third event",
+        (time + timedelta(days=40)).strftime("%B %-d, %Y, %A"): "Fourth event",
+    }
+    diary_key_list = list(diary)
+    diary_util = DiaryUtil(diary)
+
+    assert diary_util.find_event(time) == diary_key_list[0]
+    next_event_date = diary_util.find_event(time)
+    assert (
+        DiaryUtil.time_delta_event(DiaryUtil.str_to_datetime(next_event_date), time)
+        == 10
+    )
+    time = time + timedelta(days=1)
+    assert (
+        DiaryUtil.time_delta_event(DiaryUtil.str_to_datetime(next_event_date), time)
+        == 9
+    )
+    time = time + timedelta(days=1)
+    assert (
+        DiaryUtil.time_delta_event(DiaryUtil.str_to_datetime(next_event_date), time)
+        == 8
+    )
+    time = datetime(2021, 10, 31)
+    next_event_date = diary_util.find_event(time)
+    assert (
+        DiaryUtil.time_delta_event(DiaryUtil.str_to_datetime(next_event_date), time)
+        == 1
+    )


### PR DESCRIPTION
Fixes hourly edit bug with time remaining.
Previously a parameter was defaulting to a
value set at bot startup this would cause
remaining time to never change.