### PR TITLE
Custom help command

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -164,7 +164,7 @@ class CustomHelp(commands.DefaultHelpCommand): # ( ͡° ͜ʖ ͡°)
     """Custom help command"""
         
     async def send_bot_help(self, mapping):
-        "shows a list of commands"
+        """Shows a list of commands"""
         embed = discord.Embed(title="Commands Help")
         embed.colour = discord.Colour.blurple()
         for cog, commands in mapping.items():
@@ -176,18 +176,18 @@ class CustomHelp(commands.DefaultHelpCommand): # ( ͡° ͜ʖ ͡°)
         await channel.send(embed=embed)
         
     async def send_command_help(self, command):
-        "shows how to use each command"
+        """Shows how to use each command"""
         embed_command = discord.Embed(title=self.get_command_signature(command), description=command.help)
         embed_command.colour = discord.Colour.green()
         channel = self.get_destination()
         await channel.send(embed=embed_command)
 
     async def send_cog_help(self, cog):
-        "shows how to use each category"
+        """Shows how to use each category"""
         embed_cog = discord.Embed(title=cog.qualified_name, description=cog.description)
         comms = cog.get_commands()
-        for i in comms:
-            embed_cog.add_field(name=i, value=i.short_doc, inline = False)
+        for c in comms:
+            embed_cog.add_field(name=c, value=c.short_doc, inline=False)
         embed_cog.colour = discord.Colour.green()
         channel = self.get_destination()
         await channel.send(embed=embed_cog)


### PR DESCRIPTION
Just made the command more visually appealing with embed.
Most of the resources I use came from either the official [repo](https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/cog.py), the[documentation](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html?highlight=help#), and this [tutorial](https://gist.github.com/InterStella0/b78488fb28cadf279dfd3164b9f0cf96), let me know of there's any changes you want. 

![image](https://user-images.githubusercontent.com/71340731/136717503-078d9f8e-ea53-45d5-a180-cfc3bb790576.png)
