### PR TITLE
Add COVID-19 vaccine scanner plugin

### DIFF
--- a/plugins/VaccineAppointmentScanner/__init__.py
+++ b/plugins/VaccineAppointmentScanner/__init__.py
@@ -1,0 +1,116 @@
+from nextcord.ext import commands, tasks
+from Plugin import AutomataPlugin
+
+import requests
+
+## Mapping of major St. John's vaccine location IDs to location names
+LOCATIONS = {
+    949: "The Village Mall YELLOW",
+    943: "The Village Mall BLUE",
+    776: "FORMER Public Service Commission Building (50 Mundy Pond Road) (Ages <29)",
+    1668: "The Village Mall RED",
+    1669: "The Village Mall GREEN",
+    814: "Reid Community Centre (Location A) (Ages 30+)",
+    1672: "Reid Community Centre (Location B) (Ages 30+)",
+    1673: "Reid Community Centre (Location C) (Ages 30+)"
+}
+
+## The endpoint for accessing available appointment data.
+URL = "https://portal.healthmyself.net/nleasternhealth/guest/booking/type/5892/locations"
+
+class Appointments(AutomataPlugin):
+
+    def __init__(self, manifest, bot: commands.Bot):
+        super().__init__(manifest, bot)
+        self._code = ""
+        self._binded_channels = []
+        self._previous_openings = []
+        self.vaccineupdate.start()
+    
+    def cog_unload(self):
+        self.vaccineupdate.cancel()
+
+    """Return the 1st shot/2nd shot/Booster COVID-19 vaccine locations with available appointments."""
+    @commands.command()
+    async def appointments(self, ctx: commands.Context):
+        ## Accessing appointment data requires a valid hm_session cookie. We must artificially create
+        ## this cookie to gain access to this information.
+        ## (there is probably a much easier way to do this)
+        session = requests.Session()
+        session.cookies.set('hm_session', self._code)
+
+        r = session.get(URL)
+        if (r.status_code != 200):
+            message = "Request Failed! Set the hm_session code first with !setvaccinecode"
+        else:
+            available = []
+            raw_json = r.json()
+            
+            ## the retreived data is a collection of (location) id, hasUnavailableAppointment pairs.
+            for row in raw_json['data']:
+                if (row['id'] in LOCATIONS and not row['hasUnavailableAppointments']):
+                    available.append(LOCATIONS[row['id']])
+            
+            if (available):
+                message = "Appointments available at: \n" + "\n".join(available)
+            else:
+                message = "No appointments available!"
+
+        await ctx.send(message)
+    
+    """Set the hm_session cookie code for accessing vaccine information."""
+    @commands.command()
+    async def setvaccinecode(self, ctx: commands.Context, message: str):
+        self._code = message
+
+        await ctx.send("hm_session vaccine code has been set!")
+    
+    """Add the vaccine tracker to this channel, which messages the channel upon a new appointment."""
+    @commands.command()
+    async def startvaccinetracker(self, ctx: commands.Context):
+        self._binded_channels.append(ctx.channel)
+        await ctx.send("Vaccine Tracker has been added to this channel.")
+    
+    """Remove the vaccine tracker from this channel."""
+    @commands.command()
+    async def stopvaccinetracker(self, ctx: commands.Context):
+        self._binded_channels.remove(ctx.channel)
+        await ctx.send("Vaccine Tracker has been removed from this channel.")
+    
+    @tasks.loop(minutes=2.0)
+    async def vaccineupdate(self):
+        if (not self._binded_channels):
+            self._previous_openings = []
+            return
+
+        session = requests.Session()
+        session.cookies.set('hm_session', self._code)
+        message = ""
+
+        r = session.get(URL)
+        if (r.status_code != 200):
+            message = "Request Failed! Set the hm_session code first with !setvaccinecode"
+        else:
+            additions = []
+            removals = []
+            raw_json = r.json()
+
+            ## as opposed to appointments(), the tracker loop only prints differences in appointment status
+            for row in raw_json['data']:
+                if (row['id'] in LOCATIONS and not row['hasUnavailableAppointments'] and not row['id'] in self._previous_openings):
+                    self._previous_openings.append(row['id'])
+                    additions.append(LOCATIONS[row['id']])
+                elif (row['id'] in LOCATIONS and row['hasUnavailableAppointments'] and row['id'] in self._previous_openings):
+                    self._previous_openings.remove(row['id'])
+                    removals.append(LOCATIONS[row['id']])
+            
+            if (additions):
+                message = "Appointments now available at: \n" + "\n".join(additions)
+            if (additions and removals):
+                message += "\n"
+            if (removals):
+                message += "No more appointments available at: \n" + "\n".join(removals)
+
+        for channel in self._binded_channels:
+            if (message != ""):
+                await channel.send(message)

--- a/plugins/VaccineAppointmentScanner/__init__.py
+++ b/plugins/VaccineAppointmentScanner/__init__.py
@@ -1,7 +1,7 @@
 from nextcord.ext import commands, tasks
 from Plugin import AutomataPlugin
 
-import requests
+import httpx
 
 ## Mapping of major St. John's vaccine location IDs to location names
 LOCATIONS = {
@@ -36,15 +36,17 @@ class Appointments(AutomataPlugin):
     
     ## Retrieve appointment data from the booking system endpoint.
     def get_appointment_data(self):
-        session = requests.Session()
-        session.headers.update({'referer': START_URL})
-        session.get(BOOKING_URL)
+        with httpx.Client() as client:
+            client.headers.update({'referer': START_URL})
+            client.get(BOOKING_URL)
+            r = client.get(LOCATION_URL)
 
-        r = session.get(LOCATION_URL)
-        if (r.status_code != 200):
-            return None
-        else:
-            return r.json()
+            if (r.status_code != 200):
+                return None
+            else:
+                return r.json()
+        return None
+        
 
     """Return the 1st shot/2nd shot/Booster COVID-19 vaccine locations with available appointments."""
     @commands.command()

--- a/plugins/VaccineAppointmentScanner/__init__.py
+++ b/plugins/VaccineAppointmentScanner/__init__.py
@@ -25,6 +25,7 @@ BOOKING_URL = "https://portal.healthmyself.net/nleasternhealth/guest/booking/for
 LOCATION_URL = "https://portal.healthmyself.net/nleasternhealth/guest/booking/type/5892/locations"
 
 class Appointments(AutomataPlugin):
+    """Provides a utility for gathering information about COVID-19 vaccine appointments in the St. John's area."""
 
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
@@ -48,9 +49,9 @@ class Appointments(AutomataPlugin):
         return None
         
 
-    """Return the 1st shot/2nd shot/Booster COVID-19 vaccine locations with available appointments."""
     @commands.command()
     async def appointments(self, ctx: commands.Context):
+        """Return the 1st shot/2nd shot/Booster COVID-19 vaccine locations with available appointments."""
         app_data = self.get_appointment_data()
         message = ""
 
@@ -71,18 +72,19 @@ class Appointments(AutomataPlugin):
 
         await ctx.send(message)
     
-    """Add the vaccine tracker to this channel, which messages the channel upon a new appointment."""
     @commands.command()
     async def startvaccinetracker(self, ctx: commands.Context):
+        """Add the vaccine tracker to this channel, which messages the channel upon a new appointment."""
         self._binded_channels.append(ctx.channel)
         if (len(self._binded_channels) == 1):
             self.vaccineupdate.start()
 
         await ctx.send("Vaccine Tracker has been added to this channel.")
     
-    """Remove the vaccine tracker from this channel."""
     @commands.command()
     async def stopvaccinetracker(self, ctx: commands.Context):
+        """Remove the vaccine tracker from this channel."""
+
         self._binded_channels.remove(ctx.channel)
         if (len(self._binded_channels) == 0):
             self._previous_openings = []

--- a/plugins/VaccineAppointmentScanner/plugin.json
+++ b/plugins/VaccineAppointmentScanner/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "Vaccine Appointment Scanner",
+  "version": "1.0.0",
+  "author": "Andrew Harris",
+  "main_class": "Appointments"
+}


### PR DESCRIPTION
This plugin enables tracking of available COVID-19 1st dose/2nd dose/booster appointments in the St. John's/Mount Pearl metro area.

Tracking is done with these commands:
- `!appointments`: Returns the COVID-19 vaccination locations with currently available appointments.
- `!startvaccinetracker`: Binds the vaccine tracker to the current channel, which notifies the channel about changes in appointment availability.
- `!stopvaccinetracker`: Unbinds the vaccine tracker from the current channel.