### PR TITLE
Fix for 2.0.0 breaking change to motor mongo running on a different loop

### DIFF
--- a/Bot.py
+++ b/Bot.py
@@ -1,4 +1,6 @@
+import asyncio
 from dotenv import load_dotenv
+import motor.motor_asyncio
 
 from Utils import CustomHelp
 
@@ -23,7 +25,7 @@ from typing import Optional, Literal
 from Globals import (
     DISABLED_PLUGINS,
     ENABLED_PLUGINS,
-    PRIMARY_GUILD,
+    MONGO_ADDRESS,
 )
 
 IGNORED_LOGGERS = [
@@ -65,7 +67,8 @@ class Automata(commands.Bot):
         super().__init__(*args, intents=intents, **kwargs)
 
     async def setup_hook(self) -> None:
-        await self.enable_plugins()
+        self.database = motor.motor_asyncio.AsyncIOMotorClient(MONGO_ADDRESS)
+        self.loop.create_task(self.enable_plugins())
 
     async def enable_plugins(self) -> None:
         for plugin in loader.get_all_plugins():
@@ -256,6 +259,5 @@ async def sync(
         else:
             ret += 1
     await ctx.send(f"Synced the tree to {ret}/{len(guilds)}.")
-
 
 bot.run(AUTOMATA_TOKEN)

--- a/Globals.py
+++ b/Globals.py
@@ -41,7 +41,5 @@ AOC_LEADERBOARD_CHANNEL = int(
     os.getenv("AUTOMATA_ANNOUNCEMENT_CHANNEL", 909857762064871444)
 )
 
-mongo_client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_ADDRESS)
-
 if os.getenv("SENTRY_DSN", None):
     sentry_sdk.init(os.environ["SENTRY_DSN"])

--- a/plugins/3x3 Meme Generator/__init__.py
+++ b/plugins/3x3 Meme Generator/__init__.py
@@ -5,7 +5,6 @@ from discord.ext import commands
 import discord
 import httpx
 from discord.threads import Thread
-from Globals import mongo_client
 from Plugin import AutomataPlugin
 from pymongo import collection
 
@@ -20,11 +19,13 @@ class Generator(AutomataPlugin):
 
     def __init__(self, manifest, bot):
         super().__init__(manifest, bot)
+    
+    async def cog_load(self):
         self.gen3x3_sessions: collection.Collection = (
-            mongo_client.automata.gen3x3_sessions
+            self.bot.database.automata.gen3x3_sessions
         )
         self.gen3x3_session_counter: collection.Collection = (
-            mongo_client.automata.gen3x3_session_counter
+            self.bot.database.automata.gen3x3_session_counter
         )
         loop = asyncio.get_event_loop()
         document_count = loop.run_until_complete(

--- a/plugins/Agenda/__init__.py
+++ b/plugins/Agenda/__init__.py
@@ -5,7 +5,6 @@ import uuid
 from discord.ext import commands
 
 from Plugin import AutomataPlugin
-from Globals import mongo_client
 from Utils import send_code_block_maybe_as_file
 
 logger = logging.getLogger("Agenda")
@@ -34,8 +33,9 @@ class Agenda(AutomataPlugin):
 
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
-
-        self.agenda_items = mongo_client.automata.agenda_items
+    
+    async def cog_load(self):
+        self.agenda_items = self.bot.database.automata.agenda_items
 
     @commands.group()
     async def agenda(self, ctx):

--- a/plugins/Course/__init__.py
+++ b/plugins/Course/__init__.py
@@ -15,11 +15,13 @@ class Course(AutomataPlugin):
 
     def __init__(self, manifest, bot):
         super().__init__(manifest, bot)
-        # Initialize all of the web scrapers
-        self.calendar_scraper = CalendarScraper(604800)  # 1 week cache lifetime
-        self.people_scraper = PeopleScraper(604800)  # 1 week cache lifetime
-        self.rmp_scraper = RMPScraper(604800)  # 1 week cache lifetime
-        self.banner_scraper = BannerScraper(604800)  # 1 week cache lifetime
+
+    async def cog_load(self):
+        self.banner_cache = self.bot.database.automata.banner_scraper_cache
+        self.calendar_scraper = CalendarScraper(604800, self.banner_cache)  # 1 week cache lifetime
+        self.people_scraper = PeopleScraper(604800, self.banner_cache)  # 1 week cache lifetime
+        self.rmp_scraper = RMPScraper(604800, self.banner_cache)  # 1 week cache lifetime
+        self.banner_scraper = BannerScraper(604800, self.banner_cache)  # 1 week cache lifetime
 
     @commands.command()
     async def course(self, ctx: commands.Context, course_ID):

--- a/plugins/Course/bannerScraper.py
+++ b/plugins/Course/bannerScraper.py
@@ -2,7 +2,6 @@ import httpx
 from bs4 import BeautifulSoup
 import asyncio
 from datetime import datetime
-from Globals import mongo_client
 
 # The stuff between these lines was taken from https://github.com/jackharrhy/muntrunk/blob/master/muntrunk/scrape.py
 # Full credit to Jack for this stuff
@@ -21,10 +20,9 @@ headers = {
 
 
 class BannerScraper:
-    def __init__(self, cache_lifetime):
+    def __init__(self, cache_lifetime, cache):
         # Get a reference to the cache
-        self.banner_cache = mongo_client.automata.banner_scraper_cache
-
+        self.banner_cache = cache
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.setup_cache(cache_lifetime))
 

--- a/plugins/Course/calendarScraper.py
+++ b/plugins/Course/calendarScraper.py
@@ -2,17 +2,14 @@ import asyncio
 from datetime import datetime
 from bs4 import BeautifulSoup
 from urllib.request import urlopen
-from Globals import mongo_client
 
 # The URL for MUNs listing of CS courses
 calendar_url = "https://www.mun.ca/regoff/calendar/sectionNo=SCI-1023"
 
 
 class CalendarScraper:
-    def __init__(self, cache_lifetime):
-        # Get a reference to the cache
-        self.calendar_cache = mongo_client.automata.calendar_scraper_cache
-
+    def __init__(self, cache_lifetime, cache):
+        self.calendar_cache = cache
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.setup_cache(cache_lifetime))
 

--- a/plugins/Course/peopleScraper.py
+++ b/plugins/Course/peopleScraper.py
@@ -2,7 +2,6 @@ import asyncio
 import httpx
 from bs4 import BeautifulSoup
 import json
-from Globals import mongo_client
 from datetime import datetime
 
 # The URL for MUNs listing of CS faculty
@@ -10,10 +9,8 @@ url = "https://www.mun.ca/appinclude/bedrock/public/api/v1/ua/people.php?type=ad
 
 
 class PeopleScraper:
-    def __init__(self, cache_lifetime):
-        # Get a reference to the cache
-        self.people_cache = mongo_client.automata.people_scraper_cache
-
+    def __init__(self, cache_lifetime, cache):
+        self.people_cache = cache
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.setup_cache(cache_lifetime))
 

--- a/plugins/Course/rmpScraper.py
+++ b/plugins/Course/rmpScraper.py
@@ -1,6 +1,5 @@
 from bs4 import BeautifulSoup
 from urllib.request import urlopen
-from Globals import mongo_client
 from datetime import datetime
 import asyncio
 
@@ -12,10 +11,8 @@ url_parts = [
 
 
 class RMPScraper:
-    def __init__(self, cache_lifetime):
-        # Get a reference to the cache
-        self.rmp_cache = mongo_client.automata.rmp_scraper_cache
-        # Set up the cache data lifetimes
+    def __init__(self, cache_lifetime, cache):
+        self.rmp_cache = cache
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.ensure_collection_expiry(cache_lifetime))
 

--- a/plugins/ExecutiveDocs/__init__.py
+++ b/plugins/ExecutiveDocs/__init__.py
@@ -6,7 +6,6 @@ from discord.ext import commands, tasks
 
 from Plugin import AutomataPlugin
 from Globals import (
-    mongo_client,
     PRIMARY_GUILD,
     EXECUTIVE_DOCS_CHANNEL,
 )
@@ -71,12 +70,10 @@ class ExecutiveDocs(AutomataPlugin):
 
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
-
-        self.posted_documents = mongo_client.automata.executivedocs_posted_documents
-
-    @commands.Cog.listener()
-    async def on_ready(self):
-        await self.check_for_new_docs.start()
+    
+    async def cog_load(self):
+        self.posted_documents = self.bot.database.automata.executive_docs_posted_documents
+        self.check_for_new_docs.start()
 
     def cog_unload(self):
         self.check_for_new_docs.cancel()

--- a/plugins/ExecutiveDocs/__init__.py
+++ b/plugins/ExecutiveDocs/__init__.py
@@ -76,7 +76,7 @@ class ExecutiveDocs(AutomataPlugin):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        self.check_for_new_docs.start()
+        await self.check_for_new_docs.start()
 
     def cog_unload(self):
         self.check_for_new_docs.cancel()

--- a/plugins/MCWhitelist/__init__.py
+++ b/plugins/MCWhitelist/__init__.py
@@ -1,6 +1,6 @@
 import discord
 from discord.ext import commands
-from Globals import PRIMARY_GUILD, VERIFIED_ROLE, mongo_client
+from Globals import PRIMARY_GUILD, VERIFIED_ROLE
 from Plugin import AutomataPlugin
 from plugins.MCWhitelist.mojang_api import MOJANG_API_BASE, MojangAPI
 from plugins.MCWhitelist.whitelist_http_api import WhitelistHttpApi
@@ -11,13 +11,14 @@ class MCWhitelist(AutomataPlugin):
 
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
-
-        self.whitelisted_accounts = (
-            mongo_client.automata.mcwhitelist_whitelisted_accounts
-        )
-        self.disallowed_members = mongo_client.automata.mcwhitelist_disallowed_members
-        self.mojang_api = MojangAPI()
         self.whitelist_http_api = WhitelistHttpApi()
+    
+    async def cog_load(self):
+        self.whitelisted_accounts = (
+            self.bot.database.automata.mcwhitelist_whitelisted_accounts
+        )
+        self.disallowed_members = self.bot.database.automata.mcwhitelist_disallowed_members
+        self.mojang_api = MojangAPI(self.bot.database.automata.mojangapi_profile_cache)
 
     async def get_whitelisted_account(self, member):
         query = {"discord_id": member.id}

--- a/plugins/MCWhitelist/mojang_api.py
+++ b/plugins/MCWhitelist/mojang_api.py
@@ -5,7 +5,6 @@ from datetime import datetime
 
 import httpx
 
-from Globals import mongo_client
 
 MOJANG_API_BASE = "https://api.mojang.com"
 MOJANG_SESSIONSERVER_BASE = "https://sessionserver.mojang.com"
@@ -17,8 +16,8 @@ class MojangAPI:
     username_base = f"{MOJANG_API_BASE}/users/profiles/minecraft"
     profile_base = f"{MOJANG_SESSIONSERVER_BASE}/session/minecraft/profile"
 
-    def __init__(self):
-        self.profile_cache = mongo_client.automata.mojangapi_profile_cache
+    def __init__(self, profile_cache):
+        self.profile_cache = profile_cache
 
         loop = asyncio.get_event_loop()
         loop.run_until_complete(self.ensure_collection_expiry())

--- a/plugins/MUN Identity/__init__.py
+++ b/plugins/MUN Identity/__init__.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Union
 
 import httpx
 import discord
-from Globals import DISCORD_AUTH_URI, PRIMARY_GUILD, VERIFIED_ROLE, mongo_client
+from Globals import DISCORD_AUTH_URI, PRIMARY_GUILD, VERIFIED_ROLE
 from discord.ext import commands
 from Plugin import AutomataPlugin
 
@@ -13,8 +13,9 @@ class MUNIdentity(AutomataPlugin):
 
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
-
-        self.identities = mongo_client.automata.munidentity_identities
+    
+    async def cog_load(self):
+        self.identities = self.bot.database.automata.munidentity_identities
 
     async def get_identity(
         self, *, member: Union[discord.User, int] = None, mun_username: str = None

--- a/plugins/Newsline/__init__.py
+++ b/plugins/Newsline/__init__.py
@@ -9,7 +9,6 @@ from discord.ext import commands, tasks
 
 from Plugin import AutomataPlugin
 from Globals import (
-    mongo_client,
     PRIMARY_GUILD,
     NEWSLINE_CHANNEL,
 )
@@ -26,14 +25,12 @@ class Newsline(AutomataPlugin):
 
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
-
-        self.posted_posts = mongo_client.automata.newsline_posts
-        self.posted_posts.drop()
         self.posting = False
 
-    @commands.Cog.listener()
-    async def on_ready(self):
-        await self.check_for_new_posts.start()
+    async def cog_load(self):
+        self.posted_posts = self.bot.database.automata.newsline_posts
+        self.posted_posts.drop()
+        self.check_for_new_posts.start()
 
     def post_embed(self, post, post_detail):
         desc = post_detail["text"]

--- a/plugins/Newsline/__init__.py
+++ b/plugins/Newsline/__init__.py
@@ -33,7 +33,7 @@ class Newsline(AutomataPlugin):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        self.check_for_new_posts.start()
+        await self.check_for_new_posts.start()
 
     def post_embed(self, post, post_detail):
         desc = post_detail["text"]

--- a/plugins/Starboard/__init__.py
+++ b/plugins/Starboard/__init__.py
@@ -6,7 +6,7 @@ import discord
 from discord.ext import commands
 
 from Plugin import AutomataPlugin
-from Globals import mongo_client, STARBOARD_CHANNEL_ID, STARBOARD_THRESHOLD
+from Globals import STARBOARD_CHANNEL_ID, STARBOARD_THRESHOLD
 
 
 class Starboard(AutomataPlugin):
@@ -15,7 +15,8 @@ class Starboard(AutomataPlugin):
     def __init__(self, manifest, bot: commands.Bot):
         super().__init__(manifest, bot)
 
-        self.starboard = mongo_client.automata.starboard_starboard
+    async def cog_load(self):
+        self.starboard = self.bot.database.automata.starboard_starboard
 
     async def get_entry(
         self,

--- a/plugins/TodayAtMun/__init__.py
+++ b/plugins/TodayAtMun/__init__.py
@@ -30,7 +30,7 @@ class TodayAtMun(AutomataPlugin):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        self.check_for_new_event.start()
+        await self.check_for_new_event.start()
 
     def cog_unload(self):
         self.check_for_new_event.cancel()
@@ -164,7 +164,7 @@ class TodayAtMun(AutomataPlugin):
             await self.update_event_msg(next_event_date)
         await asyncio.sleep(5.0)
 
-    @tasks.loop(hours=1.0)
+    @tasks.loop(minutes=30.0)
     async def check_for_new_event(self):
         await self.post_new_events()
 


### PR DESCRIPTION
* The db was running on a diff loop than the bot, thus causing exceptions to be thrown and tasks loops to break. Amongst other plugins.
* I refactored all the plugins that were affected by stuffing the bot with the DB like the documentation suggested.

```
As a result of the asyncio changes, if you are using mongo you need to move the connecting to mongo to inside either async with bot or inside of setup_hook
async def main():
    async with bot:
        bot.database = AsyncIOMotorClient(...)
        await bot.start("TOKEN")
# OR
async def setup_hook(self):
    self.database = AsyncIOMotorClient(...)
```